### PR TITLE
db.close() should take a callback (fix #33)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -55,7 +55,7 @@ Db.prototype.createRpcStream = function () {
   });
 
   var client = self.client = rpc(null, true);
-  var rpcStream = mdm.createStream('rpc'); 
+  var rpcStream = mdm.createStream('rpc');
   rpcStream.on('error', function () {});
   client.pipe(rpcStream).pipe(client);
 
@@ -66,9 +66,10 @@ Db.prototype.createRpcStream = function () {
   return mdm;
 };
 
-Db.prototype.close = function () {
+Db.prototype.close = function (cb) {
   this._isOpen = false;
   if (this.mdm) this.mdm.end();
+  if (cb) process.nextTick(cb);
 };
 
 Db.prototype.destroy = function () {
@@ -173,7 +174,7 @@ Db.prototype._stream = function (db, k, name, type) {
         : (function () { throw new Error('not supported') })()
       );
       ts.autoDestroy = false;
-      tmp.replace(ts); 
+      tmp.replace(ts);
     });
 
     return tmp;


### PR DESCRIPTION
To match the leveldb API, let's have these guys take callbacks. All tests pass.
