### PR TITLE
make benchmarks runnable

### DIFF
--- a/bench/client.js
+++ b/bench/client.js
@@ -8,8 +8,9 @@ var str = process.argv[4];
 var write = require('./write')(str);
 
 var db = multilevel.client()
+var stream = db.createRpcStream()
 var con = net.connect(port)
-db.pipe(con).pipe(db)
+stream.pipe(con).pipe(stream)
 
 var start = Date.now()
 write(db, num, function (err, results) {

--- a/bench/index.js
+++ b/bench/index.js
@@ -52,7 +52,8 @@ function fakeNetwork (num, cb) {
     for (var i = 0; i < clients; i++) {
       var server = multilevel.server(db)
       var _db = multilevel.client()
-      _db.pipe(server).pipe(_db)
+      var stream = _db.createRpcStream()
+      stream.pipe(server).pipe(stream)
       dbs.push(_db);
     }
 


### PR DESCRIPTION
Hi!

It seem that the benchmarks haven't been updated since the api was updated.
