### PR TITLE
compatible with level-sublevel@6

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -119,7 +119,7 @@ function deprecated () {
 
 Db.prototype._buildAll = function (_db, db, path, parent) {
   var self = this;
-  var m = manifest(_db, true /* terse */);
+  var m = manifest(_db);
 
   for (var k in m.methods) {
     var method = m.methods[k];

--- a/lib/client.js
+++ b/lib/client.js
@@ -39,9 +39,7 @@ Db.prototype.sublevel = function (name) {
 };
 
 Db.prototype.prefix = function (key) {
-  if (!this._parent) return '' + (key || '');
-  return (this._parent.prefix()
-    + this._sep + this._prefix + this._sep + (key || ''));
+  return this._prefix.slice()
 };
 
 Db.prototype.createRpcStream = function () {
@@ -140,8 +138,7 @@ Db.prototype._buildAll = function (_db, db, path, parent) {
     }
   }
 
-  db._sep = _db._sep || '\xff';
-  db._prefix = _db._prefix;
+  db._prefix = path;
   db._parent = parent;
 
   for (var name in _db.sublevels) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -83,7 +83,8 @@ return function (db, opts) {
       var stream = handlers[con.meta[0]](con.meta.slice(1));
       // prevent iterators from staying open when connection fails
       con.once('error', function () {
-        stream[stream.readable ? 'destroy' : 'end']();
+        var method = stream[stream.readable ? 'destroy' : 'end']
+        if(method) method.call(stream)
       });
       if (stream.readable) stream.pipe(con);
       if (stream.writable) con.pipe(stream);

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,6 +10,11 @@ module.exports = function (MuxDemux) {
 return function (db, opts) {
   if (typeof db == 'string') throw new Error('database instance required');
 
+  if('function' === typeof db.sublevel) {
+    if(!(db.version >= '6'))
+      throw new Error('expected a level-sublevel@6 or greater')
+  }
+
   var mdm = MuxDemux({ error: true });
 
   opts = opts || {};

--- a/lib/write-manifest.js
+++ b/lib/write-manifest.js
@@ -4,6 +4,6 @@ var createManifest = require('level-manifest');
 module.exports = writeManifest;
 
 function writeManifest (db, path) {
-  var manifest = createManifest(db);
+  var manifest = createManifest(db, true /* terse mode */);
   fs.writeFileSync(path, JSON.stringify(manifest));
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "level-live-stream": "~1.4.7",
     "bops": "~0.1.0",
     "through": "~2.3.4",
-    "level-sublevel": "~6.0.0",
+    "level-sublevel": "~6.1.4",
     "memdb": "~0.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "level-live-stream": "~1.4.7",
     "bops": "~0.1.0",
     "through": "~2.3.4",
-    "level-sublevel": "~5.1.1",
+    "level-sublevel": "~6.0.0",
     "memdb": "~0.1.0"
   },
   "engines": {

--- a/test/nested-stream.js
+++ b/test/nested-stream.js
@@ -22,9 +22,10 @@ require('./util')(function (test, _, getDb) {
           t.equal(data.value, 'bar')
         })
         .on('end', function () {
-          var stream = db.writeStream()
-          stream.write({ key : 'bar', value : 'baz' })
-          stream.on('close', function () {
+          db.batch([
+            { key : 'bar', value : 'baz' }
+          ], function (err) {
+            if(err) throw err
             // temporary fix for level-js
             setTimeout(function () {
               db.get('bar', function (err, value) {
@@ -34,7 +35,6 @@ require('./util')(function (test, _, getDb) {
               });
             }, 100);
           })
-          stream.end()
         })
       })
     })


### PR DESCRIPTION
This updates multilevel to work with level-sublevel@6
level-sublevel is currently released with the dev tag (not latest)
I'm still making sure it's as compatible with the most important modules that depend on it.

It's mostly still compatible, but the way that prefixes are handled has changed,
and multilevel used this, so this was a breaking change for multilevel.

level-sublevel is basically a peer dep, so I have exposed the version on the v6 sublevel instance
and added a check on multilevel that throws a helpful error message, if you pass it a sublevel db)
if you are using multilevel without sublevel then it still works.

