### PR TITLE
write manifest.json in a more human readable way

### DIFF
--- a/lib/write-manifest.js
+++ b/lib/write-manifest.js
@@ -5,5 +5,5 @@ module.exports = writeManifest;
 
 function writeManifest (db, path) {
   var manifest = createManifest(db);
-  fs.writeFileSync(path, JSON.stringify(manifest));
+  fs.writeFileSync(path, JSON.stringify(manifest, null, 2));
 }


### PR DESCRIPTION
Makes it easier to `cat manifest.json` to see methods and also to `diff manifest1.json manifest2.json` to note differences.