### PR TITLE
wip client side custom encodings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
   - "0.10"
+  - "0.12"
+  - "iojs"

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ var manifest = require('level-manifest');
 var combine = require('stream-combiner');
 var inherits = require('util').inherits;
 var tmpStream = require('tmp-stream');
+var codec = require('level-codec');
 
 module.exports = function (MuxDemux) {
 
@@ -23,6 +24,7 @@ function Db (m) {
 
   this.mdm = null;
   this.client = null;
+  this.codec = new codec.Codec(m.options);
   var self = this;
 
   this._buildAll(m, this, [], null);
@@ -170,10 +172,66 @@ Db.prototype._asyncSync = function (db, k, name) {
       if (err) db.emit('error', err)
     };
 
+    var optsIdx = self._getOpts(k, args);
+    var opts = args[optsIdx] || {};
+    var tempOpts = {};
+
+    self._encodeArgs(k, args, opts, tempOpts);
+
+    if (k == 'get' || k == 'put' || k == 'del' || k == 'batch') {
+      if (self.codec.keyAsBuffer(opts)) tempOpts.keyEncoding = 'binary';
+      if (self.codec.valueAsBuffer(opts)) tempOpts.valueEncoding = 'binary';
+      if (typeof optsIdx == 'number') {
+        args[optsIdx] = tempOpts;
+      } else {
+        args.push(tempOpts);
+      }
+    }
+
     self._queue(function () {
-      self.client.rpc(name, args, cb);
+      self.client.rpc(name, args, function () {
+        var cbArgs = [].slice.call(arguments);
+        self._decodeArgs(k, cbArgs, opts);
+        cb.apply(db, cbArgs);
+      });
     });
   };
+};
+
+Db.prototype._getOpts = function (k, args) {
+  if (k == 'get' || k == 'del' || k == 'batch') return 1;
+  if (k == 'put') return 2;
+};
+
+Db.prototype._encodeArgs = function (k, args, opts, tempOpts) {
+  var self = this;
+
+  var keyIdx;
+  if (k == 'get' || k == 'del' || k == 'put') keyIdx = 0;
+
+  var valueIdx;
+  if (k == 'put') valueIdx = 1;
+
+  var opsIdx;
+  if (k == 'batch') opsIdx = 0;
+
+  if (typeof keyIdx != 'undefined') {
+    args[keyIdx] = this.codec.encodeKey(args[keyIdx], opts);
+    if (this.codec.keyAsBuffer(opts)) tempOpts.keyEncoding = 'binary';
+  }
+  if (typeof valueIdx != 'undefined') {
+    args[valueIdx] = this.codec.encodeValue(args[valueIdx], opts);
+    if (this.codec.valueAsBuffer(opts)) tempOpts.valueIdxEncoding = 'binary';
+  }
+  if (typeof opsIdx != 'undefined') {
+    args[opsIdx] = this.codec.encodeBatch(args[opsIdx], opts);
+  }
+};
+
+Db.prototype._decodeArgs = function (k, cbArgs, opts) {
+  if (k == 'get' && !cbArgs[0]) {
+    cbArgs[1] = this.codec.decodeValue(cbArgs[1], opts);
+  }
 };
 
 Db.prototype._stream = function (db, k, name, type) {
@@ -212,4 +270,8 @@ Db.prototype._queue = function (fn) {
 return Db;
 
 };
+
+function isObject (o) {
+  return o !== null && typeof o == 'object';
+}
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,7 +9,7 @@ var manifest = require('level-manifest');
 var combine = require('stream-combiner');
 var inherits = require('util').inherits;
 var tmpStream = require('tmp-stream');
-var codec = require('level-codec');
+var Codec = require('level-codec');
 
 module.exports = function (MuxDemux) {
 
@@ -24,7 +24,7 @@ function Db (m) {
 
   this.mdm = null;
   this.client = null;
-  this.codec = new codec.Codec(m.options);
+  this.codec = new Codec(m.options);
   var self = this;
 
   this._buildAll(m, this, [], null);

--- a/lib/client.js
+++ b/lib/client.js
@@ -124,6 +124,7 @@ function deprecated () {
 Db.prototype._buildAll = function (_db, db, path, parent) {
   var self = this;
   var m = manifest(_db, true /* terse */);
+  var isLeveldb = db == self || !!parent; // not nested object
 
   for (var k in m.methods) {
     var method = m.methods[k];
@@ -133,7 +134,7 @@ Db.prototype._buildAll = function (_db, db, path, parent) {
     if (type == 'error') throw new Error(method.message || 'not supported');
 
     if (/async|sync/.test(type)) {
-      self._asyncSync(db, k, name);
+      self._asyncSync(db, k, name, isLeveldb);
     } else if (/readable|writable/.test(type)) {
       self._stream(db, k, name, type);
     } else if (type == 'object') {
@@ -154,7 +155,7 @@ Db.prototype._buildAll = function (_db, db, path, parent) {
   }
 };
 
-Db.prototype._asyncSync = function (db, k, name) {
+Db.prototype._asyncSync = function (db, k, name, isLeveldb) {
   var self = this;
 
   db[k] = function () {
@@ -172,26 +173,30 @@ Db.prototype._asyncSync = function (db, k, name) {
       if (err) db.emit('error', err)
     };
 
-    var optsIdx = self._getOpts(k, args);
-    var opts = args[optsIdx] || {};
-    var tempOpts = {};
+    var optsIdx, opts, tempOpts;
 
-    self._encodeArgs(k, args, opts, tempOpts);
+    if (isLeveldb) {
+      optsIdx = self._getOpts(k, args);
+      opts = args[optsIdx] || {};
+      tempOpts = {};
 
-    if (k == 'get' || k == 'put' || k == 'del' || k == 'batch') {
-      if (self.codec.keyAsBuffer(opts)) tempOpts.keyEncoding = 'binary';
-      if (self.codec.valueAsBuffer(opts)) tempOpts.valueEncoding = 'binary';
-      if (typeof optsIdx == 'number') {
-        args[optsIdx] = tempOpts;
-      } else {
-        args.push(tempOpts);
+      self._encodeArgs(k, args, opts, tempOpts);
+
+      if (k == 'get' || k == 'put' || k == 'del' || k == 'batch') {
+        if (self.codec.keyAsBuffer(opts)) tempOpts.keyEncoding = 'binary';
+        if (self.codec.valueAsBuffer(opts)) tempOpts.valueEncoding = 'binary';
+        if (typeof optsIdx == 'number') {
+          args[optsIdx] = tempOpts;
+        } else {
+          args.push(tempOpts);
+        }
       }
     }
 
     self._queue(function () {
       self.client.rpc(name, args, function () {
         var cbArgs = [].slice.call(arguments);
-        self._decodeArgs(k, cbArgs, opts);
+        if (isLeveldb) self._decodeArgs(k, cbArgs, opts);
         cb.apply(db, cbArgs);
       });
     });

--- a/package.json
+++ b/package.json
@@ -20,19 +20,22 @@
   "license": "MIT",
   "dependencies": {
     "duplexer": "~0.1.1",
-    "rpc-stream": "~2.1.1",
+    "level-codec": "^4.2.0",
     "level-manifest": "~1.2.0",
-    "stream-combiner": "0.0.2",
     "mux-demux": "~3.7.8",
+    "rpc-stream": "~2.1.1",
+    "stream-combiner": "0.0.2",
     "tmp-stream": "~0.3.2"
   },
   "devDependencies": {
-    "tape": "~2.3.0",
-    "level-live-stream": "~1.4.7",
     "bops": "~0.1.0",
-    "through": "~2.3.4",
+    "bytewise": "^0.8.0",
+    "level": "^0.18.0",
+    "level-live-stream": "~1.4.7",
     "level-sublevel": "~5.1.1",
-    "memdb": "~0.1.0"
+    "memdb": "~0.1.0",
+    "tape": "~2.3.0",
+    "through": "~2.3.4"
   },
   "engines": {
     "node": ">0.6"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "duplexer": "~0.1.1",
-    "level-codec": "^4.2.0",
+    "level-codec": "^5.2.0",
     "level-manifest": "~1.2.0",
     "mux-demux": "~3.7.8",
     "rpc-stream": "~2.1.1",

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,0 +1,90 @@
+var getDb = require('./util').getDb;
+var bytewise = require('bytewise');
+
+require('./util')(function (test, _, getDb) {
+
+  test('string encoding', function (t) {
+    getDb(function (db, dispose) {
+      db.batch([
+        { type: 'put', key: 'string', value: 'string' },
+        { type: 'put', key: 'buffer', value: Buffer('buffer') } 
+      ], function (err) {
+        t.error(err);
+
+        db.get('string', function (err, val) {
+          t.error(err);
+
+          t.notOk(Buffer.isBuffer(val), 'no buffer');
+          t.equal(val, 'string', 'correct value');
+
+          db.get('buffer', function (err, val) {
+            t.error(err);
+
+            t.notOk(Buffer.isBuffer(val), 'no buffer');
+            t.equal(val, 'buffer', 'correct value');
+
+            t.end();
+            dispose();
+          });
+        });
+      });
+    });
+  });
+
+  test('binary encoding', function (t) {
+    getDb(function (db, dispose) {
+      db.batch([
+        { type: 'put', key: 'string', value: 'string', valueEncoding: 'binary' },
+        { type: 'put', key: 'buffer', value: Buffer('buffer') } 
+      ], function (err) {
+        t.error(err);
+
+        db.get('string', { valueEncoding: 'binary' }, function (err, val) {
+          t.error(err);
+
+          t.ok(Buffer.isBuffer(val), 'is buffer');
+          t.equal(val.toString(), 'string', 'correct value');
+
+          db.get('buffer', { valueEncoding: 'binary' }, function (err, val) {
+            t.error(err);
+
+            t.ok(Buffer.isBuffer(val), 'is buffer');
+            t.equal(val.toString(), 'buffer', 'correct value');
+
+            t.end();
+            dispose();
+          });
+        });
+      });
+    });
+  });
+
+  test('custom encoding', function (t) {
+    getDb(function (db, dispose) {
+      db.batch([
+        { type: 'put', key: 'string', value: 'string', valueEncoding: bytewise },
+        { type: 'put', key: 'buffer', value: bytewise.encode('buffer') } 
+      ], function (err) {
+        t.error(err);
+
+        db.get('string', { valueEncoding: bytewise }, function (err, val) {
+          t.error(err);
+
+          t.notOk(Buffer.isBuffer(val), 'no buffer');
+          t.equal(val, 'string', 'correct value');
+
+          db.get('buffer', { valueEncoding: bytewise }, function (err, val) {
+            t.error(err);
+
+            t.notOk(Buffer.isBuffer(val), 'no buffer');
+            t.equal(val, 'buffer', 'correct value');
+
+            t.end();
+            dispose();
+          });
+        });
+      });
+    });
+  });
+
+})

--- a/test/util.js
+++ b/test/util.js
@@ -1,8 +1,8 @@
-var MemDB = require('memdb');
 var manifest = require('level-manifest');
 var tape = require('tape');
 var multilevel = require('..');
 var multilevelMsgpack = require('../msgpack');
+var level = require('level');
 
 var DEBUG = process.env.DEBUG;
   
@@ -25,7 +25,9 @@ var util = module.exports = function (tests) {
   );
 };
 
-util.getLocalDb = MemDB;
+util.getLocalDb = function(){
+  return level('/tmp/' + Math.random().toString(16).slice(2));
+};
 
 util.createGetDb = function (multilevel) {
   return function (setup, cb) {


### PR DESCRIPTION
This adds the ability to pass custom encodings on the client, so `db.put(key, value, { valueEncoding: require('bytewise') })` etc work.

This isn't here yet. Aside from code quality, the problem I'm having is with custom methods, as added by a manifest. In `Db.prototype._syncAsync` I'm currently checking the method name to see whether this is a standard levelup method and thus should be treated like one - in this case this means that encoding logic will be applied. If there's however something like a custom `.get()` method, we can't say any more that the signature is `(key[, opts][, callback])`.

I see 2 solutions currently:

1) find some way to distinguish standard levelup methods from custom methods. Problem: there's no way to know probably.
2) enforce an argument structure for custom methods. Problem: Say a method wants to have 3 string arguments...which is key, which is value, etc? Or enforce custom methods to have arguments `([opts][, callback])`

What do you think?

From the top of my head: @dominictarr @dweinstein @hij1nx @ralphtheninja 
