### PR TITLE
Return manifest

### DIFF
--- a/lib/write-manifest.js
+++ b/lib/write-manifest.js
@@ -6,4 +6,5 @@ module.exports = writeManifest;
 function writeManifest (db, path) {
   var manifest = createManifest(db, true /* terse mode */);
   fs.writeFileSync(path, JSON.stringify(manifest));
+  return manifest;
 }

--- a/test/node/manifest.js
+++ b/test/node/manifest.js
@@ -4,8 +4,9 @@ var MemDB = require('memdb');
 
 test('write manifest', function (t) {
   var db = MemDB();
-  writeManifest(db, __dirname + '/manifest.json');
+  var result = writeManifest(db, __dirname + '/manifest.json');
   var manifest = require('./manifest.json');
   t.ok(manifest);
+  t.deepEqual(result, manifest);
   t.end();
 });


### PR DESCRIPTION
We already have the string and might as well return it so caller doesn't have to read the file to get the manifest.