### PR TITLE
add failing stream error test

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -93,6 +93,9 @@ return function (db, opts) {
       });
       if (stream.readable) stream.pipe(con);
       if (stream.writable) con.pipe(stream);
+      stream.on('error', function (err) {
+        con.error(flatten(err));
+      });
     } catch (err) {
       mdm.emit('error', err);
     }

--- a/test/stream-error.js
+++ b/test/stream-error.js
@@ -1,0 +1,28 @@
+var multilevel = require('..');
+var through = require('through');
+var MemDB = require('memdb');
+
+require('./util')(function (test) {
+
+  test('stream error', function (t) {
+    var db = {};
+    db.createReadStream = function(){
+      var stream = through();
+      process.nextTick(function(){
+        stream.emit('error', new Error('oops'));
+      });
+      return stream;
+    };
+
+    var server = multilevel.server(db);
+    var client = multilevel.client();
+    server.pipe(client.createRpcStream()).pipe(server);
+
+    var stream = client.createReadStream();
+    stream.on('error', function(err){
+      t.equal(err.message, 'oops');
+      t.end();
+    });
+  });
+});
+


### PR DESCRIPTION
this should work, but doesn't currently.

when a stream on the server emits an error, it should not crash the server, but rather be forwarded to the client.

any suggestions, especially @dominictarr?